### PR TITLE
Fix some z-index problem with CoverCard and titles

### DIFF
--- a/patterns/layered-card/Cover.tsx
+++ b/patterns/layered-card/Cover.tsx
@@ -13,6 +13,7 @@ const Cover: React.FC<{}> = () => {
                     justifyContent: 'center',
                     padding: '1.5rem',
                     position: 'relative',
+                    zIndex: 0,
                 }}
             >
                 <div

--- a/patterns/tooltip/Cover.tsx
+++ b/patterns/tooltip/Cover.tsx
@@ -32,7 +32,6 @@ const Cover: React.FC<{}> = () => {
                             position: 'absolute',
                             transform: 'translate(-50%, 4px)',
                             width: 0,
-                            zIndex: 10,
                         }}
                     />
                     <div
@@ -45,7 +44,6 @@ const Cover: React.FC<{}> = () => {
                             position: 'absolute',
                             transform: 'translate(-50%, -4px)',
                             width: '80px',
-                            zIndex: 10,
                         }}
                     />
                     <Rectangle height={16} />


### PR DESCRIPTION
When scrolling the home page, some cards using `z-index` inside their Pattern component conflicts with the Title's `z-index`, causing the card content to overlap the Title component.

![csslayout](https://user-images.githubusercontent.com/12896082/135633038-5638a70c-5a83-4c8d-990c-2dfaec1a7956.gif)

![csslayout2](https://user-images.githubusercontent.com/12896082/135633048-ff7166cf-155e-4ccb-8d15-8e3720639726.gif)

This changes fixes the two cards with that problem.